### PR TITLE
solve issue: next is not a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "is-promise": "^2.1.0"
   },
   "devDependencies": {
-    "mongoose": "^4.11.10"
+    "mongoose": "^6.2.9"
   }
 }

--- a/src/applyGetters.js
+++ b/src/applyGetters.js
@@ -1,6 +1,6 @@
 const isPromise = require('is-promise')
 
-module.exports = (getters, options) => function (doc, next) {
+module.exports = (getters, options) => function (doc) {
   // doc === this
   const promises = []
 
@@ -25,12 +25,8 @@ module.exports = (getters, options) => function (doc, next) {
     }
   }
 
-  Promise
-    .all(promises)
-    // wait till all promises are complete
-    .then(() => next())
-    // centralized error handling
-    .catch((err) => next(err))
+  return Promise.all(promises)
+
 }
 
 const applyGetter = (doc, path, result) => {

--- a/src/applySetters.js
+++ b/src/applySetters.js
@@ -1,6 +1,6 @@
 const isPromise = require('is-promise')
 
-module.exports = (setters, options) => function (next) {
+module.exports = (setters, options) => function () {
   const doc = this
   const promises = []
 
@@ -28,12 +28,7 @@ module.exports = (setters, options) => function (next) {
     }
   }
 
-  Promise
-    .all(promises)
-    // wait till all promises are complete
-    .then(() => next())
-    // centralized error handling
-    .catch((err) => next(err))
+  return Promise.all(promises)
 }
 
 const applySetter = (doc, path, result) => {

--- a/test/index.js
+++ b/test/index.js
@@ -8,9 +8,7 @@ const timeout = (timeout) => new Promise((resolve) => {
 
 // SETUP MONGOOSE
 mongoose.Promise = Promise
-mongoose.connect('mongodb://localhost:27017/mongoose-async', {
-  useMongoClient: true,
-})
+mongoose.connect('mongodb://localhost:27017/mongoose-async')
 mongoose.connection.on('error', (err) => console.error(err))
 mongoose.connection.on('open', () => console.log('db ok'))
 


### PR DESCRIPTION
Starting from mongoose 5.x. Instead of calling next() manually in pre or post middleware functions, our functions should return a promise, or in particular, we can use async/await.

1- So I removed next() from applySetter() and applyGetter() and make them return a promise instead. 
2- in package.json: changed mongoose version in devDependencies from "^4.11.10" to "^6.2.9". 
3- in test/index.js: removed `useMongoClient: true` option from mongoose.connect() as it no longer supports it.